### PR TITLE
Add cairo-gobject-devel to dockerfile

### DIFF
--- a/runner/docker/qubesos-ci/Dockerfile
+++ b/runner/docker/qubesos-ci/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="Frédéric Pierret <frederic.pierret@qubes-os.org>"
 
 RUN dnf -y install \
     ca-certificates \
+    cairo-gobject-devel \
     createrepo \
     curl \
     debootstrap \


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/10724

---

Reading [Marek's comment](https://github.com/QubesOS/qubes-issues/issues/10724#issuecomment-3992780149), it seems that there are extra manual steps that need to be done by the person hosting the gitlab runner.