### PR TITLE
fix: increase sshd startup timeout

### DIFF
--- a/runner/kvm/custom.conf
+++ b/runner/kvm/custom.conf
@@ -5,3 +5,5 @@ ConditionPathExists=/var/lib/qubes-service/sshd
 
 [Service]
 ExecStartPre=+/usr/local/bin/setup-dom0-net.sh
+TimeoutSec=600
+


### PR DESCRIPTION
Starting sys-net may take a bit of time.